### PR TITLE
Pin snowpack version to fix breaking change in snowpack

### DIFF
--- a/packages/microsite/package.json
+++ b/packages/microsite/package.json
@@ -68,7 +68,7 @@
     "rollup": "^2.32.1",
     "rollup-plugin-styles": "^3.11.0",
     "sirv": "^1.0.10",
-    "snowpack": "^3.0.0-rc.2"
+    "snowpack": "3.0.0-rc.2"
   },
   "devDependencies": {
     "@types/node": "^12.19.0",


### PR DESCRIPTION
Updating `package.json` in order to pin the version of `snowpack` depended on to the last version before [the `createConfiguration` API was changed](https://github.com/snowpackjs/snowpack/pull/1972). This fixes the issue mentioned in #87.