### PR TITLE
Fix preact import regex matching other things

### DIFF
--- a/docs/advanced/global-state.md
+++ b/docs/advanced/global-state.md
@@ -12,7 +12,7 @@ Microsite's partial hydration method manages each component as a seperate Preact
 Components can consume this global state object via **`useGlobalState(state)`**.
 
 ```tsx
-// utils/state.tsx
+// utils/state.ts
 import { createGlobalState } from "microsite/global";
 
 export const state = createGlobalState({

--- a/docs/basic/styling.md
+++ b/docs/basic/styling.md
@@ -42,7 +42,7 @@ Microsite automatically detects if you have a PostCSS configuration file and wil
 
 ## CSS-in-JS
 
-Microsite currently support some CSS-in-JS solutions.
+Support for CSS-in-JS solutions is coming in `v1.1.0`. There are currently some examples on the `v1.1.0` branch, but more will be added soon.
 
-- [Fela](../../examples/with-fela)
-- [Goober](../../examples/with-goober)
+- [Fela](https://github.com/natemoo-re/microsite/tree/v1.1.0/examples/with-fela)
+- [Goober](https://github.com/natemoo-re/microsite/tree/v1.1.0/examples/with-goober)

--- a/docs/basic/styling.md
+++ b/docs/basic/styling.md
@@ -42,4 +42,7 @@ Microsite automatically detects if you have a PostCSS configuration file and wil
 
 ## CSS-in-JS
 
-Microsite does not currently support CSS-in-JS solutions, but this is a high priority for the next release.
+Microsite currently support some CSS-in-JS solutions.
+
+- [Fela](../../examples/with-fela)
+- [Goober](../../examples/with-goober)

--- a/docs/basic/typescript.md
+++ b/docs/basic/typescript.md
@@ -41,7 +41,7 @@ To imporve the type inference for `getStaticPaths` and `getStaticProps`, you may
 ```tsx
 import { definePage } from 'microsite/page';
 
-const MyPage = () => {};
+const Post = () => {};
 
 export default definePage(Post, {
     path: '/posts/[slug]',

--- a/packages/microsite/src/utils/build.tsx
+++ b/packages/microsite/src/utils/build.tsx
@@ -54,7 +54,7 @@ export const proxyImportTransformer = {
     }),
 };
 
-const PREACT_IMPORT_REGEX = /^.*_snowpack/pkg/preact([\/\w]+)?\.js$/gm;
+const PREACT_IMPORT_REGEX = /^.*_snowpack\/pkg\/preact([\/\w]+)?\.js$/gm;
 export const preactImportTransformer = {
   filter: (source: string) => PREACT_IMPORT_REGEX.test(source),
   transform: (source: string) =>

--- a/packages/microsite/src/utils/build.tsx
+++ b/packages/microsite/src/utils/build.tsx
@@ -54,7 +54,7 @@ export const proxyImportTransformer = {
     }),
 };
 
-const PREACT_IMPORT_REGEX = /^.*preact([\/\w]+)?\.js$/gm;
+const PREACT_IMPORT_REGEX = /^.*_snowpack/pkg/preact([\/\w]+)?\.js$/gm;
 export const preactImportTransformer = {
   filter: (source: string) => PREACT_IMPORT_REGEX.test(source),
   transform: (source: string) =>


### PR DESCRIPTION
Currently preact import regex matches other things (e.g @mdx-js/preact).

Fixes #134

Fix turned out to be slightly more complicated. This hardcodes part of the snowpack folder structure into the regex. I’m not sure whether that’s alright?

The alternative would be dynamically determine the path, but I’m not familiar enough with snowpack/this codebase/node in general to know where that function would live. 