### PR TITLE
Fix incorrect field used for aliases from snowpack user config

### DIFF
--- a/docs/advanced/global-state.md
+++ b/docs/advanced/global-state.md
@@ -12,7 +12,7 @@ Microsite's partial hydration method manages each component as a seperate Preact
 Components can consume this global state object via **`useGlobalState(state)`**.
 
 ```tsx
-// utils/state.tsx
+// utils/state.ts
 import { createGlobalState } from "microsite/global";
 
 export const state = createGlobalState({

--- a/docs/basic/styling.md
+++ b/docs/basic/styling.md
@@ -42,7 +42,7 @@ Microsite automatically detects if you have a PostCSS configuration file and wil
 
 ## CSS-in-JS
 
-Microsite currently support some CSS-in-JS solutions.
+Support for CSS-in-JS solutions is coming in `v1.1.0`. There are currently some examples on the `v1.1.0` branch, but more will be added soon.
 
-- [Fela](../../examples/with-fela)
-- [Goober](../../examples/with-goober)
+- [Fela](https://github.com/natemoo-re/microsite/tree/v1.1.0/examples/with-fela)
+- [Goober](https://github.com/natemoo-re/microsite/tree/v1.1.0/examples/with-goober)

--- a/docs/basic/styling.md
+++ b/docs/basic/styling.md
@@ -42,4 +42,7 @@ Microsite automatically detects if you have a PostCSS configuration file and wil
 
 ## CSS-in-JS
 
-Microsite does not currently support CSS-in-JS solutions, but this is a high priority for the next release.
+Microsite currently support some CSS-in-JS solutions.
+
+- [Fela](../../examples/with-fela)
+- [Goober](../../examples/with-goober)

--- a/docs/basic/typescript.md
+++ b/docs/basic/typescript.md
@@ -41,7 +41,7 @@ To imporve the type inference for `getStaticPaths` and `getStaticProps`, you may
 ```tsx
 import { definePage } from 'microsite/page';
 
-const MyPage = () => {};
+const Post = () => {};
 
 export default definePage(Post, {
     path: '/posts/[slug]',

--- a/packages/microsite/src/utils/command.ts
+++ b/packages/microsite/src/utils/command.ts
@@ -49,7 +49,7 @@ export async function loadConfiguration(mode: "dev" | "build") {
         ..._config,
         plugins: [...additionalPlugins, ..._config.plugins, ...(userConfig.plugins ?? [])],
         alias: {
-          ...(userConfig.aliases ?? {}),
+          ...(userConfig.alias ?? {}),
           ...aliases,
           ...(_config.alias ?? {}),
           "microsite/hydrate": "microsite/client/hydrate",
@@ -66,7 +66,7 @@ export async function loadConfiguration(mode: "dev" | "build") {
         ..._config,
         plugins: [...additionalPlugins, ..._config.plugins, ...(userConfig.plugins ?? [])],
         alias: {
-          ...(userConfig.aliases ?? {}),
+          ...(userConfig.alias ?? {}),
           ...aliases,
           ...(_config.alias ?? {}),
         },


### PR DESCRIPTION
Uses the wrong field from `userConfig`. According to `snowpack.config.js` [documentation](https://www.snowpack.dev/reference/configuration#alias), the aliases field is called just `alias` and not `aliases`.

I've just changed it in this PR, but it might be worth loading both for now (for backwards compatibility) and dropping the incorrect field in a new release?