### PR TITLE
Ensure nested imports are hydrated, allow optional display name override for named exports

### DIFF
--- a/packages/microsite/src/hydrate.tsx
+++ b/packages/microsite/src/hydrate.tsx
@@ -5,6 +5,7 @@ const isServer = typeof window === "undefined";
 export const HydrateContext = createContext<string | false>(false);
 
 export interface HydrationProps {
+  displayName?: string;
   method?: "idle" | "visible";
   fallback?: VNode<any> | null;
 }
@@ -13,7 +14,7 @@ export function withHydrate<T extends FunctionComponent<any>>(
   Component: T,
   hydrationProps: HydrationProps = {}
 ): T {
-  const name = Component.displayName || Component.name;
+  const name = hydrationProps.displayName || Component.displayName || Component.name;
   const { method, fallback: Fallback } = hydrationProps;
 
   const Wrapped: FunctionComponent<any> = (props, ref) => {


### PR DESCRIPTION
WARNING: hacky stateful mess 🙃 

Fixes two issues:

1. Nested imports of hydrated components sometimes not being included in the manifest
2. Failure to hydrate components assigned to named exports