### PR TITLE
Fix `withHydrate` wrapped named exports

### DIFF
--- a/.changeset/cool-geckos-thank.md
+++ b/.changeset/cool-geckos-thank.md
@@ -1,0 +1,5 @@
+---
+"microsite": patch
+---
+
+Fix an issue where named exports would not be properly hydrated

--- a/.changeset/smooth-eyes-count.md
+++ b/.changeset/smooth-eyes-count.md
@@ -1,0 +1,5 @@
+---
+"microsite": patch
+---
+
+Fix bug where useGlobalState would cause builds to fail

--- a/benchmark/microsite/counter/package.json
+++ b/benchmark/microsite/counter/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "husky": "^4.3.0",
     "lint-staged": "^10.4.2",
-    "microsite": "^1.1.0",
+    "microsite": "1.2.1",
     "prettier": "^2.1.2"
   },
   "husky": {

--- a/benchmark/microsite/static/package.json
+++ b/benchmark/microsite/static/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "husky": "^4.3.0",
     "lint-staged": "^10.4.2",
-    "microsite": "^1.1.0",
+    "microsite": "1.2.1",
     "prettier": "^2.1.2"
   },
   "husky": {

--- a/examples/dynamic-routes/src/pages/index.tsx
+++ b/examples/dynamic-routes/src/pages/index.tsx
@@ -15,7 +15,7 @@ const Index: FunctionalComponent<any> = ({ renderedAt }) => {
         <ul>
           {Array.from({ length: 5 }, (_, i) => (
             <li>
-              <a href={`/posts/${i + 1}`}>Page {i + 1}</a>
+              <a href={`./posts/${i + 1}`}>Page {i + 1}</a>
             </li>
           ))}
         </ul>

--- a/examples/dynamic-routes/src/pages/posts/[id].tsx
+++ b/examples/dynamic-routes/src/pages/posts/[id].tsx
@@ -17,7 +17,7 @@ const Index: FunctionalComponent<any> = ({ num }) => {
 
         <p>
           Head to{" "}
-          <a href={`/posts/${nextPage}`}>
+          <a href={`./posts/${nextPage}`}>
             <code>/posts/{nextPage}</code>
           </a>
         </p>

--- a/examples/named-exports/package.json
+++ b/examples/named-exports/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/named-exports",
+  "homepage": "/named-exports",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "microsite",
+    "build": "microsite build -- --debug-hydration",
+    "serve": "microsite build -- --debug-hydration --serve"
+  },
+  "devDependencies": {
+    "microsite": "1.2.1"
+  }
+}

--- a/examples/named-exports/snowpack.config.js
+++ b/examples/named-exports/snowpack.config.js
@@ -1,0 +1,8 @@
+import { resolve, join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const workspaceRoot = resolve(join(dirname(fileURLToPath(import.meta.url)), '..', '..'));
+
+export default {
+    workspaceRoot
+}

--- a/examples/named-exports/src/components/default-and-named.tsx
+++ b/examples/named-exports/src/components/default-and-named.tsx
@@ -1,0 +1,18 @@
+import { withHydrate } from "microsite/hydrate";
+
+const DefaultComponent = () => (
+  <h1>
+    Hello <code>default</code>
+  </h1>
+);
+const NamedComponentInternal = () => (
+  <h1>
+    Hello <code>named</code>
+  </h1>
+);
+
+export const NamedComponent = withHydrate(NamedComponentInternal, {
+  method: "idle",
+});
+
+export default withHydrate(DefaultComponent, { method: "idle" });

--- a/examples/named-exports/src/components/default.tsx
+++ b/examples/named-exports/src/components/default.tsx
@@ -1,0 +1,9 @@
+import { withHydrate } from "microsite/hydrate";
+
+const DefaultComponent = () => (
+  <h1>
+    Hello <code>default</code>
+  </h1>
+);
+
+export default withHydrate(DefaultComponent, { method: "idle" });

--- a/examples/named-exports/src/components/named.tsx
+++ b/examples/named-exports/src/components/named.tsx
@@ -1,0 +1,11 @@
+import { withHydrate } from "microsite/hydrate";
+
+const NamedComponentInternal = () => (
+  <h1>
+    Hello <code>named</code>
+  </h1>
+);
+
+export const NamedComponent = withHydrate(NamedComponentInternal, {
+  method: "idle",
+});

--- a/examples/named-exports/src/pages/index.tsx
+++ b/examples/named-exports/src/pages/index.tsx
@@ -1,0 +1,29 @@
+import { FunctionalComponent } from "preact";
+import { definePage } from "microsite/page";
+import { Head, seo } from "microsite/head";
+
+import DefaultComponentA from "../components/default";
+import { NamedComponent as NamedComponentA } from "../components/named";
+import DefaultComponentB, {
+  NamedComponent as NamedComponentB,
+} from "../components/default-and-named";
+
+const Index: FunctionalComponent = () => {
+  return (
+    <>
+      <Head>
+        <seo.title>Named Exports</seo.title>
+      </Head>
+
+      <main>
+        <DefaultComponentA />
+        <DefaultComponentB />
+
+        <NamedComponentA />
+        <NamedComponentB />
+      </main>
+    </>
+  );
+};
+
+export default definePage(Index);

--- a/examples/named-exports/tsconfig.json
+++ b/examples/named-exports/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "microsite/base",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "prebenchmark:microsite": "yarn build:core",
     "benchmark:microsite": "node scripts/benchmark --suite microsite-simple",
     "bootstrap:ci": "npx lerna bootstrap --ci",
-    "bootstrap:examples": "npx lerna bootstrap --scope='microsite' --scope='@example/*' --ci",
-    "bootstrap:benchmark": "npx lerna bootstrap --scope='microsite' --scope='@benchmark/*' --ci",
     "build": "npx lerna run build --scope='microsite' --scope='create-microsite' --sort",
     "postbuild": "lerna link",
     "build:core": "yarn workspace microsite run build",

--- a/packages/microsite/package.json
+++ b/packages/microsite/package.json
@@ -20,6 +20,7 @@
   "exports": {
     "./base": "./base.json",
     "./base.json": "./base.json",
+    "./runtime": "./dist/runtime/index.js",
     "./client/csr": "./dist/client/csr.js",
     "./client/hooks": "./dist/client/hooks.js",
     "./client/hydrate": "./dist/client/hydrate.js",
@@ -33,7 +34,6 @@
     "./assets/snowpack-plugin.cjs": "./assets/snowpack-plugin.cjs",
     "./assets/snowpack.config.cjs": "./assets/snowpack.config.cjs",
     "./assets/types/*": "./assets/types/*.d.ts",
-    "./assets/microsite-runtime.js": "./assets/microsite-runtime.js",
     "./package.json": "./package.json"
   },
   "files": [
@@ -56,6 +56,7 @@
     "polka": "^0.5.2",
     "preact": "^10.5.13",
     "preact-render-to-string": "^5.1.16",
+    "recast": "^0.20.4",
     "rollup": "^2.32.1",
     "rollup-plugin-styles": "^3.11.0",
     "sirv": "^1.0.10",

--- a/packages/microsite/src/cli/microsite-build.ts
+++ b/packages/microsite/src/cli/microsite-build.ts
@@ -573,7 +573,7 @@ async function bundlePagesForSSR(paths: string[]) {
           const hydrated = hydrateMap[file.replace(/\.js$/, "")];
           entry.hydrateBindings[file] = Object.keys(exports).reduce(
             (acc, key) => {
-              return Object.assign(acc, { [hydrated[key]]: key });
+              return Object.assign(acc, { [hydrated[key] || key]: key });
             },
             {}
           );
@@ -594,7 +594,6 @@ const rewriteHydratedComponentDisplayNames = (): Plugin => {
           visitCallExpression(path) {
             if (path.get("callee").getValueProperty("name") === "withHydrate") {
               const exportName = path.parent.get("id").getValueProperty("name");
-
               const innerName = path.parent
                 .get("init", "arguments", 0)
                 .getValueProperty("name");

--- a/packages/microsite/src/cli/microsite-build.ts
+++ b/packages/microsite/src/cli/microsite-build.ts
@@ -253,6 +253,7 @@ async function bundlePagesForSSR(paths: string[]) {
       );
     },
     plugins: [
+      rewriteSnowpackPreact(),
       rewriteCssProxies(),
       rewritePreact(),
       rewriteHydratedComponentDisplayNames(),
@@ -622,6 +623,21 @@ const rewriteHydratedComponentDisplayNames = (): Plugin => {
         name: "hydrateMap.json",
         source: JSON.stringify(withHydrateMap),
       });
+    },
+  };
+};
+
+/**
+ * Snowpack rewrites CSS to a `.css.proxy.js` file.
+ * Great for dev, but we need to revert to the actual CSS file
+ */
+const rewriteSnowpackPreact = () => {
+  return {
+    name: "@microsite/rollup-rewrite-snowpack-preact",
+    resolveId(source: string) {
+      if (source.indexOf("pkg/preact") > -1)
+        return source.slice(source.indexOf("preact"), -3);
+      return null;
     },
   };
 };

--- a/packages/microsite/src/cli/microsite-build.ts
+++ b/packages/microsite/src/cli/microsite-build.ts
@@ -256,7 +256,7 @@ async function bundlePagesForSSR(paths: string[]) {
       rewriteSnowpackPreact(),
       rewriteCssProxies(),
       rewritePreact(),
-      rewriteHydratedComponentDisplayNames(),
+      collecHydrateMap(),
       styles({
         config: true,
         mode: "extract",
@@ -584,10 +584,10 @@ async function bundlePagesForSSR(paths: string[]) {
     });
 }
 
-const rewriteHydratedComponentDisplayNames = (): Plugin => {
+const collecHydrateMap = (): Plugin => {
   let withHydrateMap: Record<string, Record<string, string>> = {};
   return {
-    name: "@microsite/rollup-rewrite-hydrated-component-display-names",
+    name: "@microsite/rollup-collec-hydrate-map",
     renderChunk(code: string, chunk: RenderedChunk) {
       if (chunk.name.startsWith("_hydrate/")) {
         const ast = this.parse(code);

--- a/packages/microsite/src/hydrate.tsx
+++ b/packages/microsite/src/hydrate.tsx
@@ -10,39 +10,50 @@ export interface HydrationProps {
   fallback?: VNode<any> | null;
 }
 
+const encode = (str: string) => Buffer.from(str).toString("base64");
+
 export function withHydrate<T extends FunctionComponent<any>>(
   Component: T,
   hydrationProps: HydrationProps = {}
 ): T {
-  const name = hydrationProps.displayName || Component.displayName || Component.name;
+  const innerName = Component.name;
   const { method, fallback: Fallback } = hydrationProps;
 
-  const Wrapped: FunctionComponent<any> = (props, ref) => {
+  return (function (props: any, ref: any) {
     const hydrateParent = useContext(HydrateContext);
     if (hydrateParent)
       throw new Error(
-        `withHydrate() should only be called at the top-level of a Component tree. <${name} /> should not be nested within <${hydrateParent} />`
+        `withHydrate() should only be called at the top-level of a Component tree. <${innerName} /> should not be nested within <${hydrateParent} />`
       );
 
     if (props.children && !["string", "number"].includes(typeof props.children))
       throw new Error(
-        `withHydrate() is unable to serialize complex \`children\`. Please inline these children into <${name} />.`
+        `withHydrate() is unable to serialize complex \`children\`. Please inline these children into <${innerName} />.`
       );
 
-    const p = isServer ? `p=${JSON.stringify(props)}` : '';
-    const m = isServer && method ? `m=${method}` : '';
-    const f = isServer && typeof Fallback !== 'undefined' ? 'f=1' : '';
-    const Marker = 'hydrate-marker' as any;
-    const Placeholder = 'hydrate-placeholder' as 'div';
+    const p = isServer ? `p=${encode(JSON.stringify(props))}` : "";
+    const m = isServer && method ? `m=${method}` : "";
+    const f = isServer && typeof Fallback !== "undefined" ? "f=1" : "";
+    const Marker = "hydrate-marker" as any;
+    const Placeholder = "hydrate-placeholder" as "div";
     return (
-      <HydrateContext.Provider value={name}>
-        {isServer && (<Marker dangerouslySetInnerHTML={{ __html: `?h c=${name} ?` }} />)}
-        {typeof Fallback !== 'undefined' ? (Fallback || <Placeholder />) : <Component {...{ ...props, ref }} />}
-        {isServer && (<Marker dangerouslySetInnerHTML={{ __html: `?h ${[p, m, f].filter(v => v).join(' ')} ?` }} />)}
+      <HydrateContext.Provider value={innerName}>
+        {isServer && (
+          <Marker dangerouslySetInnerHTML={{ __html: `?h c=${innerName} ?` }} />
+        )}
+        {typeof Fallback !== "undefined" ? (
+          Fallback || <Placeholder />
+        ) : (
+          <Component {...{ ...props, ref }} />
+        )}
+        {isServer && (
+          <Marker
+            dangerouslySetInnerHTML={{
+              __html: `?h ${[p, m, f].filter((v) => v).join(" ")} ?`,
+            }}
+          />
+        )}
       </HydrateContext.Provider>
     );
-  };
-
-  Object.defineProperty(Wrapped, "name", { value: name, configurable: true });
-  return (Wrapped as unknown) as T;
+  } as unknown) as T;
 }

--- a/packages/microsite/src/utils/build.tsx
+++ b/packages/microsite/src/utils/build.tsx
@@ -31,7 +31,7 @@ export const setBasePath = (p: string) =>
 export interface ManifestEntry {
   name: string;
   hydrateStyleBindings: string[] | null;
-  hydrateBindings: Record<string, string[]> | null;
+  hydrateBindings: Record<string, Record<string, string>> | null;
 }
 
 export interface RouteDataEntry {

--- a/packages/microsite/src/utils/hydration.ts
+++ b/packages/microsite/src/utils/hydration.ts
@@ -1,9 +1,5 @@
 import type { ManifestEntry } from "./build";
 
-// This is an esbuild (?) bug where default exports are rewritten with a number appended
-// so we'll just remove any trailing numbers
-const cleanComponentName = (cmp: string) => cmp.replace(/[0-9]+$/, "");
-
 export function generateHydrateScript(
   hydrateBindings: ManifestEntry["hydrateBindings"],
   opts: { basePath?: string } = {}
@@ -12,9 +8,9 @@ export function generateHydrateScript(
   const entries = Object.fromEntries(
     Object.entries(hydrateBindings)
       .map(([file, exports]) =>
-        exports.map((cmp) => [
-          cleanComponentName(cmp),
-          [cmp, `${basePath}${file}`],
+        Object.entries(exports).map(([key, exportName]) => [
+          key,
+          [exportName, `${basePath}${file}`],
         ])
       )
       .flat(1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,6 +1634,13 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+ast-types@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
+  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+  dependencies:
+    tslib "^2.0.1"
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -2968,7 +2975,7 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -6722,6 +6729,16 @@ readdir-scoped-modules@^1.0.0:
     graceful-fs "^4.1.2"
     once "^1.3.0"
 
+recast@^0.20.4:
+  version "0.20.4"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.20.4.tgz#db55983eac70c46b3fff96c8e467d65ffb4a7abc"
+  integrity sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==
+  dependencies:
+    ast-types "0.14.2"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tslib "^2.0.1"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -7199,7 +7216,7 @@ source-map@^0.5.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.1:
+source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -7758,7 +7775,7 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0:
+tslib@^2.0.1, tslib@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==


### PR DESCRIPTION
Fixes #147! Also fixed a few other bugs I encountered along the way.

Based on @nikita-graf's awesome suggestion of traversing the AST in a Rollup plugin, except I'm not actually modifying the AST to inject any variables. Instead, a components local `name` is still used as the hydration key (`c=InternalComponent`) but the Rollup plugin finds the `withHydrate` HOC calls and emits a JSON file which maps hydration keys (internal Component names) to the exported Component identifiers. This was tested manually against a new `named-exports` example as well as the existing examples (which all used `export default withHydrate(Component)`).