### PR TITLE
Add fetch to global object in dev env

### DIFF
--- a/packages/microsite/src/cli/microsite-dev.tsx
+++ b/packages/microsite/src/cli/microsite-dev.tsx
@@ -14,6 +14,7 @@ import {
   generateStaticPropsContext,
   normalizePathName,
 } from "../utils/router.js";
+import fetch from "../server/fetch.js";
 
 const noop = () => Promise.resolve();
 
@@ -26,6 +27,9 @@ let __HeadContext: any;
 let __InternalDocContext: any;
 let ErrorPage: any;
 let errorSrc: string;
+
+declare var global: NodeJS.Global & { fetch: typeof fetch };
+global.fetch = fetch;
 
 const loadErrorPage = async () => {
   if (!ErrorPage) {


### PR DESCRIPTION
Hi
I tried to use `fetch` inside `getStaticProps` and it just doesn't work in `dev` (for `build` it works just fine because it is imported by add fetch on transformation).
I'm not sure if `node-fetch` should be injected for that situation with other tools but I just tried to put `fetch` in nodejs global object for `microsite dev`.

